### PR TITLE
Id torrent by infohash

### DIFF
--- a/apps/etorrent/include/types.hrl
+++ b/apps/etorrent/include/types.hrl
@@ -34,6 +34,12 @@
 % Types used by the DHT subsystem
 -type ipaddr() :: {byte(), byte(), byte(), byte()}.
 -type portnum() :: 1..16#FFFF.
+% Currently there are two flavors of info hash used in etorrent
+% code. One is a 160-bit binary produced by crypto:sha/1. The other
+% is an integer decoded from such binary, which is used exclusively
+% by DHT. DHT subsystem also uses it as node id and computes nodes
+% distance by 'xor' their ids. Xor can not be applied on binaries.
+% Thus the distinction.
 -type infohash() :: pos_integer().
 -type nodeid() :: pos_integer().
 -type nodeinfo() :: {nodeid(), ipaddr(), portnum()}.

--- a/apps/etorrent/src/etorrent_fs_checker.erl
+++ b/apps/etorrent/src/etorrent_fs_checker.erl
@@ -29,15 +29,14 @@ check_torrent_for_bad_pieces(Id) ->
 	   end].
 
 % @doc Read and check a torrent
-% <p>The torrent given by Id, at Path (the .torrent file) will be checked for
+% <p>The torrent given by Id, and parsed content will be checked for
 %  correctness. We return a tuple
 %  with various information about said torrent: The decoded Torrent dictionary,
 %  the info hash and the number of pieces in the torrent.</p>
 % @end
--spec read_and_check_torrent(integer(), string()) -> {ok, bcode(), binary(), integer()}.
-read_and_check_torrent(Id, Path) ->
-    {ok, Torrent, Infohash, Hashes} =
-        initialize_dictionary(Id, Path),
+-spec read_and_check_torrent(integer(), bcode()) -> {ok, integer()}.
+read_and_check_torrent(Id, Torrent) ->
+    {ok, Hashes} = initialize_dictionary(Id, Torrent),
 
     L = length(Hashes),
 
@@ -63,7 +62,7 @@ read_and_check_torrent(Id, Path) ->
             ok = initialize_pieces_from_disk(FS, Id, Hashes)
     end,
 
-    {ok, Torrent, Infohash, L}.
+    {ok, L}.
 
 %% @doc Check a piece for completion and mark it for correctness
 %% @end
@@ -97,19 +96,10 @@ check_piece(TorrentID, PieceIndex) ->
 
 %% =======================================================================
 
-initialize_dictionary(Id, Path) ->
-    %% Load the torrent
-    {ok, Torrent, IH} = load_torrent(Path),
+initialize_dictionary(Id, Torrent) ->
     ok = etorrent_io:allocate(Id),
     Hashes = etorrent_metainfo:get_pieces(Torrent),
-    {ok, Torrent, IH, Hashes}.
-
-load_torrent(Path) ->
-    Workdir = etorrent_config:work_dir(),
-    P = filename:join([Workdir, Path]),
-    {ok, Torrent} = etorrent_bcoding:parse_file(P),
-    InfoHash = etorrent_metainfo:get_infohash(Torrent),
-    {ok, Torrent, InfoHash}.
+    {ok, Hashes}.
 
 initialize_pieces_seed(Id, Hashes) ->
     L = length(Hashes),

--- a/apps/etorrent/src/etorrent_io_sup.erl
+++ b/apps/etorrent/src/etorrent_io_sup.erl
@@ -11,20 +11,17 @@
 -export([init/1]).
 
 %% @doc Initiate the supervisor.
-%% <p>The arguments are the ID of the torrent and the file-path at
-%% which the torrent file lives</p>
+%% <p>The arguments are the ID of the torrent and the
+%% parsed torrent file</p>
 %% @end
--spec start_link(torrent_id(), file_path()) -> {'ok', pid()}.
-start_link(TorrentID, TorrentFile) ->
-    supervisor:start_link(?MODULE, [TorrentID, TorrentFile]).
+-spec start_link(torrent_id(), bcode()) -> {'ok', pid()}.
+start_link(TorrentID, Torrent) ->
+    supervisor:start_link(?MODULE, [TorrentID, Torrent]).
 
 %% ----------------------------------------------------------------------
 
 %% @private
-init([TorrentID, TorrentFile]) ->
-    Workdir   = etorrent_config:work_dir(),
-    FullPath  = filename:join([Workdir, TorrentFile]),
-    {ok, Torrent}   = etorrent_bcoding:parse_file(FullPath),
+init([TorrentID, Torrent]) ->
     Files     = etorrent_metainfo:file_paths(Torrent),
     DirServer = directory_server_spec(TorrentID, Torrent),
     Dldir     = etorrent_config:download_dir(),

--- a/apps/etorrent/src/etorrent_table.erl
+++ b/apps/etorrent/src/etorrent_table.erl
@@ -25,7 +25,7 @@
 
 %% Torrent information
 -export([all_torrents/0, statechange_torrent/2, get_torrent/1, acquire_check_token/1,
-	 new_torrent/3]).
+	 new_torrent/4]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -47,7 +47,7 @@
 -record(tracking_map, {id :: '_' | integer(), %% Unique identifier of torrent
                        filename :: '_' | string(),    %% The filename
                        supervisor_pid :: '_' | pid(), %% The Pid of who is supervising
-                       info_hash :: '_' | binary() | 'unknown',
+                       info_hash :: '_' | binary(),
                        state :: '_' | tracking_map_state()}).
 
 
@@ -184,16 +184,19 @@ new_peer(IP, Port, TorrentId, Pid, State) ->
     add_monitor(peer, Pid).
 
 %% @doc Add a new torrent
-%% <p>The torrent is given by File with the Supervisor pid as given to the
-%% database structure.</p>
+%% <p>The torrent is given by File and its infohash with the
+%% Supervisor pid as given to the database structure.</p>
 %% @end
--spec new_torrent(string(), pid(), integer()) -> ok.
-new_torrent(File, Supervisor, Id) when is_integer(Id), is_pid(Supervisor), is_list(File) ->
+-spec new_torrent(string(), binary(), pid(), integer()) -> ok.
+new_torrent(File, IH, Supervisor, Id) when is_integer(Id),
+                                        is_pid(Supervisor),
+                                        is_binary(IH),
+                                        is_list(File) ->
     add_monitor({torrent, Id}, Supervisor),
     TM = #tracking_map { id = Id,
 			 filename = File,
 			 supervisor_pid = Supervisor,
-			 info_hash = unknown,
+			 info_hash = IH,
 			 state = awaiting},
     true = ets:insert(tracking_map, TM),
     ok.


### PR DESCRIPTION
Hi,

I added some comments about why etorrent uses both binary and integer info hash. This is also part of fix to refactor the code to identify torrent by its info hash instead of file path.

Please review the change.

Regards,
Edward
