### PR TITLE
Private torrent

### DIFF
--- a/apps/etorrent/src/etorrent_table.erl
+++ b/apps/etorrent/src/etorrent_table.erl
@@ -175,7 +175,7 @@ all_peer_pids(Id) ->
 %% @end
 -spec all_peers_of_tracker(string()) -> {value, [pid()]}.
 all_peers_of_tracker(Url) ->
-    R = ets:match(peers, #peer{tracker_url_hash = erlang:phase2(Url),
+    R = ets:match(peers, #peer{tracker_url_hash = erlang:phash2(Url),
                                pid = '$1', _ = '_'}),
     {value, [Pid || [Pid] <- R]}.
 

--- a/apps/etorrent/src/etorrent_tracker_communication.erl
+++ b/apps/etorrent/src/etorrent_tracker_communication.erl
@@ -177,7 +177,8 @@ contact_tracker_tier([Url | Next], Event, S, Acc) ->
 	    %% For private torrent (BEP 27), disconnect all peers coming
 	    %% from the tracker before switching to another one
 	    case etorrent_torrent:is_private(S#state.torrent_id) of
-	        true -> disconnect_tracker(Url)
+	        true -> disconnect_tracker(Url);
+	        _ -> ok
 	    end,
 	    contact_tracker_tier(Next, Event, S, [Url | Acc])
     end.


### PR DESCRIPTION
This patch disconnects from all current peers when switching to another tracker if the torrent is private. It is supposed to be part of the effort to make etorrent BEP 27 compliant.

Please review. 
