### PR TITLE
update relx-dev.config vm.args copy

### DIFF
--- a/relx-dev.config
+++ b/relx-dev.config
@@ -10,7 +10,7 @@
            {mkdir, "spool"},
            {mkdir, "data"},
            {copy, "rel/vm.args",
-            "releases/\{\{release_name\}\}-\{\{release_version\}\}/vm.args"}
+            "releases/\{\{release_version\}\}/vm.args"}
           ]}.
 
 


### PR DESCRIPTION
Recent relx changed the output structure to be releases/<rel_version> instead of releases/<rel_name>-<rel_version> in order to work with release_handler. Here I've made the change to relx.config overlay for that.

You could also use 

```
{vm_args, "rel/vm.args"}.
```

Instead, like you do for `sys.config`.
